### PR TITLE
chore: updates manifest to inject react app into dom, matches only github

### DIFF
--- a/public/contentScript.js
+++ b/public/contentScript.js
@@ -1,0 +1,17 @@
+function init() {
+    const iframe = document.createElement("iframe");
+
+    // Styles
+    iframe.style.display = "block";
+    iframe.style.position = "fixed";
+    iframe.style.top = "0px";
+    iframe.style.left = "0px";
+    iframe.style.height = "100%";
+    iframe.style.border = "none";
+
+    iframe.src = chrome.runtime.getURL("index.html");
+
+    document.body.appendChild(iframe);
+}
+
+init();

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,5 +4,21 @@
   "version": "1.0.1",
   "action": {
     "default_popup": "index.html"
-  }
+  },
+  "content_scripts": [{
+    "matches": ["https://github.com/"],
+    "js": ["contentScript.js"],
+    "run_at": "document_end",
+    "all_frames": true
+  }],
+  "host_permissions": ["<all_urls>"],
+  "permissions": [
+    "scripting"
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["*"],
+      "matches": ["<all_urls>"]
+    }
+  ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+
+// TODO: makes dedicated enrties for popup and content script
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
Пока popup и content одинаковый
Нужно сделать потом разные entries в vite config чтобы паралелить вьюхи

Еще надо бы подумать обернуть например iframe и чтобы он дровер эффектом открывал и скрывался

Проблема popup в том что он заново инициализирует приложение тут надо background.js использовать чтобы ему данные прокидывать (будут в фоне) или делать запросы в popup и класть в localstorage при первом открытии - ЭТО НАДО ПОДУМАТЬ

<img width="1727" alt="изображение" src="https://github.com/wi-untitled/github-exts/assets/10350366/3743dbc7-fcc1-45db-b9d1-09f4c904ddd1">