### PR TITLE
fix(settings): overstack of fn in listeners stack for autoupdates

### DIFF
--- a/public/contentScript.js
+++ b/public/contentScript.js
@@ -28,6 +28,8 @@ function init() {
 
         if (document.querySelector("#notifyier")) {
             div.removeChild(notifyier);
+
+            hasDiff = false;
         }
     }
 
@@ -75,14 +77,8 @@ function init() {
                 case "NOTIFY_BROADCAST": {
                     hasDiff = hasDiff || data.data.hasDiff;
 
-                    if (hasDiff) {
-                        /**
-                         * TODO: There is setTimeout to make fake delay.
-                         * In future it can be removed.
-                         */
-                        setTimeout(() => {
-                            div.appendChild(notifyier);
-                        }, 3000);
+                    if (hasDiff && !document.querySelector("#notifyier")) {
+                        div.appendChild(notifyier);
                     }
 
                     return;

--- a/src/modules/SettingsWidgetsClassic/SettingsWidgetsClassic.tsx
+++ b/src/modules/SettingsWidgetsClassic/SettingsWidgetsClassic.tsx
@@ -9,6 +9,7 @@ import {
 } from "./components";
 import { WidgetsId } from "src/enums";
 import { GlobalDeveloper } from "src/components";
+import { Tooltip } from "src/components/Tooltip";
 
 function SettingsWidgetClassicComponent() {
     const settingsStore = useStore("SettingsStore");
@@ -72,12 +73,17 @@ function SettingsWidgetClassicComponent() {
                         title={t("settingsWidgets.widgetTitleTooltipText")}
                         onChange={handleToggleWidgetTitleTooltipCallback}
                     />
-                    <SettingsSwitch
+                    <Tooltip
                         id="autoUpdateEnabled"
-                        enabled={settingsStore.isAutoUpdateEnabled}
-                        title={t("settingsWidgets.autoUpdate")}
-                        onChange={handleAutoUpdateEnabled}
-                    />
+                        info={t("settingsWidgets.autoUpdateInfo")}
+                    >
+                        <SettingsSwitch
+                            id="autoUpdateEnabled"
+                            enabled={settingsStore.isAutoUpdateEnabled}
+                            title={t("settingsWidgets.autoUpdate")}
+                            onChange={handleAutoUpdateEnabled}
+                        />
+                    </Tooltip>
                 </div>
                 <div>
                     <SaveSettingsButton

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -53,7 +53,7 @@ export class NotificationsService extends AppService {
             });
 
             const response = await octokit.rest.search.issuesAndPullRequests({
-                q: `reviewed-by:@me+is:pull-request+created:>${NotificationsService.createdLastWeek()}+state:open+review:changes_requested`,
+                q: `author:@me+is:pull-request+created:>${NotificationsService.createdLastWeek()}+state:open+review:changes_requested`,
             });
 
             return {

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -99,13 +99,13 @@ export class AppStore extends BaseStore implements IState {
         if (action === "IFRAME_TOGGLE") {
             this.updateIsOpen(isOpen);
         }
-        // TODO: test message
-        this.transport.sendMessageRuntime({
-            action: "BROADCAST",
-            data: {
-                test: 42,
-            },
-        });
+        // TODO: example how to make broadcast message
+        // this.transport.sendMessageRuntime({
+        //     action: "BROADCAST",
+        //     data: {
+        //         test: 42,
+        //     },
+        // });
     };
 
     protected handleAutoUpdateChange = ({


### PR DESCRIPTION
Когда открываешь/закрываешь расширение, то не было проверки на то, что уже обработчик зарегестрирован. Из-за этого после некоторого времени вызов функция дублировался.